### PR TITLE
String dtypes from schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ venv:
 	[ -d ./venv ] || python3 -m venv venv
 	./venv/bin/pip install --upgrade pip
 	./venv/bin/pip install pytest pytest-cov
-	./venv/bin/pip install twine wheel setuptools --upgrade
+	./venv/bin/pip install twine wheel setuptools geopandas --upgrade
 	./venv/bin/pip install -e .
 
 .PHONY: publish-on-pypi test-pypi-install venv

--- a/pandas_datapackage_reader/__init__.py
+++ b/pandas_datapackage_reader/__init__.py
@@ -101,6 +101,8 @@ def read_datapackage(url_or_path, resource_name=None):
                     dtypes[column["name"]] = "float64"
                 elif col_type == "integer":
                     dtypes[column["name"]] = "Int64"
+                elif col_type == "string":
+                    dtypes[column["name"]] = "object"
 
         if format == "csv":
             df = pd.read_csv(

--- a/tests/test-package/datapackage.json
+++ b/tests/test-package/datapackage.json
@@ -59,6 +59,24 @@
             }
         },
         {
+            "name": "datawithstringnumbers",
+            "path": "datawithints.csv",
+            "format": "csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "intid",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "intvalue",
+                        "type": "string"
+                    }
+                ],
+                "primaryKey": "intid"
+            }
+        },
+        {
             "name": "moredata",
             "path": "moredata.csv",
             "format": "csv",

--- a/tests/test_pandas_datapackage_reader.py
+++ b/tests/test_pandas_datapackage_reader.py
@@ -86,7 +86,7 @@ def test_missing_integer_values():
 
 def test_missing_integer_values_with_index():
     df = read_datapackage(os.path.join(path, "test-package"), "datawithindex")
-    assert pd.isnull(df.loc[2])
+    assert pd.isnull(df.loc[2].intvalue)
     assert df["intvalue"].dtype == pd.Int64Dtype()
 
 

--- a/tests/test_pandas_datapackage_reader.py
+++ b/tests/test_pandas_datapackage_reader.py
@@ -1,5 +1,6 @@
 import os
 import pandas as pd
+import numpy as np
 import pytest
 import requests
 import sys
@@ -100,6 +101,10 @@ def test_datetimes():
     assert df["yearmonth"].iloc[0] == pd.Period("2017-01")
     assert df["yearmonth"].iloc[0] == pd.Period("2017-01")
     assert df["dayfirstdate"].iloc[0] == date(2017, 12, 13)
+
+def test_strings():
+    df = read_datapackage(os.path.join(path, "test-package"), "datawithstringnumbers")
+    assert df["intvalue"].dtype == np.dtype(object)
 
 
 def test_metadata():


### PR DESCRIPTION
Use `object` dtype for fields of type `string`

For fields that are described as type `string` in the datapackage, use the `object` dtype when reading the data.