### PR TITLE
Add sdist to pypi release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ publish-on-pypi:
 	@rm -rf build dist
 	@status=$$(git status --porcelain); \
 	if test "x$${status}" = x; then \
-		./venv/bin/python setup.py bdist_wheel --universal; \
+		./venv/bin/python setup.py sdist bdist_wheel --universal; \
 		./venv/bin/twine upload dist/*; \
 	else \
 		echo Working directory is dirty >&2; \


### PR DESCRIPTION
@rgieseke I want to get pymagicc onto conda (https://github.com/conda-forge/staged-recipes/pull/10475). To do that, pandas datapackage reader needs to be on conda too. For that, the source distribution needs to be on Pypi. This PR adds that :)