### PR TITLE
Wrap setting index in try/except

### DIFF
--- a/pandas_datapackage_reader/__init__.py
+++ b/pandas_datapackage_reader/__init__.py
@@ -144,7 +144,10 @@ def read_datapackage(url_or_path, resource_name=None):
 
         # Set index column
         if index_col:
-            df = df.set_index(index_col)
+            try:
+                df = df.set_index(index_col)
+            except KeyError:
+                raise KeyError("Error dealing with {}".format(name))
 
         # Add resource description as a `_metadata` attribute. This won't
         # survive methods returning new DataFrames but can be useful.


### PR DESCRIPTION
Addresses #14 

Prints name of resource when error in setting index (e.g. if column name is missing or misspelled).