### PR TITLE
Get thousands separator from field level, if defined

### DIFF
--- a/pandas_datapackage_reader/__init__.py
+++ b/pandas_datapackage_reader/__init__.py
@@ -102,14 +102,13 @@ def read_datapackage(url_or_path, resource_name=None):
             decimal_char = resource["schema"].get("decimalChar", '.')
             thousands_sep = resource["schema"].get("groupChar", None)
 
-            # Get encoding
-            encoding = resource.get("encoding", 'utf8')
-
             if "fields" in resource["schema"]:
                 for column in resource["schema"]["fields"]:
                     col_type = column.get("type", None)
                     if col_type == "number":
                         dtypes[column["name"]] = "float64"
+                        #Get thousands separator from field level, if defined
+                        thousands_sep = column.get("groupChar", thousands_sep)
                     elif col_type == "integer":
                         dtypes[column["name"]] = "Int64"
                     elif col_type == "string":
@@ -124,7 +123,6 @@ def read_datapackage(url_or_path, resource_name=None):
                 dtype=dtypes,
                 thousands=thousands_sep,
                 decimal=decimal_char,
-                encoding=encoding,
             )
         elif format == "geojson":
             import geopandas

--- a/pandas_datapackage_reader/__init__.py
+++ b/pandas_datapackage_reader/__init__.py
@@ -102,6 +102,9 @@ def read_datapackage(url_or_path, resource_name=None):
             decimal_char = resource["schema"].get("decimalChar", '.')
             thousands_sep = resource["schema"].get("groupChar", None)
 
+            # Get encoding
+            encoding = resource.get("encoding", 'utf8')
+
             if "fields" in resource["schema"]:
                 for column in resource["schema"]["fields"]:
                     col_type = column.get("type", None)
@@ -121,6 +124,7 @@ def read_datapackage(url_or_path, resource_name=None):
                 dtype=dtypes,
                 thousands=thousands_sep,
                 decimal=decimal_char,
+                encoding=encoding,
             )
         elif format == "geojson":
             import geopandas

--- a/pandas_datapackage_reader/__init__.py
+++ b/pandas_datapackage_reader/__init__.py
@@ -98,17 +98,17 @@ def read_datapackage(url_or_path, resource_name=None):
             # Get missing values representations if defined
             missing_values = resource["schema"].get("missingValues", [''])
 
-            # Get decimal character and thousands separator if they are defined
+            # Get decimal character if they are defined
             decimal_char = resource["schema"].get("decimalChar", '.')
-            thousands_sep = resource["schema"].get("groupChar", None)
 
             if "fields" in resource["schema"]:
                 for column in resource["schema"]["fields"]:
                     col_type = column.get("type", None)
+                    # Get thousands separator from field level, if defined.
+                    # Note that this will be applied to all fields.
+                    thousands_sep = column.get("groupChar", None)
                     if col_type == "number":
                         dtypes[column["name"]] = "float64"
-                        #Get thousands separator from field level, if defined
-                        thousands_sep = column.get("groupChar", thousands_sep)
                     elif col_type == "integer":
                         dtypes[column["name"]] = "Int64"
                     elif col_type == "string":

--- a/tests/test-package/datapackage.json
+++ b/tests/test-package/datapackage.json
@@ -160,25 +160,6 @@
                     },
                     {
                         "name": "value",
-                        "type": "number"
-                    }
-                ],
-                "primaryKey": "id",
-                "groupChar": ","
-            }
-        },
-        {
-            "name": "datawiththousands-fieldlevel",
-            "path": "datawiththousands.csv",
-            "format": "csv",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "id",
-                        "type": "integer"
-                    },
-                    {
-                        "name": "value",
                         "type": "number",
                         "groupChar": ","
                     }

--- a/tests/test-package/datapackage.json
+++ b/tests/test-package/datapackage.json
@@ -168,6 +168,25 @@
             }
         },
         {
+            "name": "datawiththousands-fieldlevel",
+            "path": "datawiththousands.csv",
+            "format": "csv",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "value",
+                        "type": "number",
+                        "groupChar": ","
+                    }
+                ],
+                "primaryKey": "id"
+            }
+        },
+        {
           "name": "json-only",
           "format": "json",
           "path": "only.json"

--- a/tests/test_pandas_datapackage_reader.py
+++ b/tests/test_pandas_datapackage_reader.py
@@ -136,3 +136,7 @@ def test_decimal_char():
 def test_group_char():
     df = read_datapackage(os.path.join(path, "test-package"), "datawiththousands")
     assert df['value'].dtype == float
+
+def test_group_char2():
+    df = read_datapackage(os.path.join(path, "test-package"), "datawiththousands-fieldlevel")
+    assert df['value'].dtype == float

--- a/tests/test_pandas_datapackage_reader.py
+++ b/tests/test_pandas_datapackage_reader.py
@@ -137,6 +137,3 @@ def test_group_char():
     df = read_datapackage(os.path.join(path, "test-package"), "datawiththousands")
     assert df['value'].dtype == float
 
-def test_group_char2():
-    df = read_datapackage(os.path.join(path, "test-package"), "datawiththousands-fieldlevel")
-    assert df['value'].dtype == float


### PR DESCRIPTION
There is no option at the column level in Pandas. The proposition is to use the separator defined at the field level for all columns.